### PR TITLE
HMI 1.12 changelogs

### DIFF
--- a/hmi_changelog.md
+++ b/hmi_changelog.md
@@ -8,6 +8,17 @@
 - Important optimizations 
 - New TwinCAT HMI Project Generator template
 
+## Version 1.12.748.0
+- Resolving of references, pointers and interface pointers. See [InfoSys](https://infosys.beckhoff.com/content/1033/te2000_tc3_hmi_engineering/10740011531.html?id=3958689380699327712).
+
+## Version 1.12
+- Black or whitelisting of symbols through the use of pragmas. See [InfoSys](https://infosys.beckhoff.com/content/1033/te2000_tc3_hmi_engineering/10740009611.html ).
+- Support for properties and method calls. See [InfoSys](https://infosys.beckhoff.com/content/1033/te2000_tc3_hmi_engineering/10740006667.html?id=1586893120692980090). (Note: Properties have worked before in older version in a similar way. Not sure what has changed other than an icon difference.)
+- Multiple server instances on one system. See [InfoSys](https://infosys.beckhoff.com/content/1033/tf2000_tc3_hmi_server/10740576267.html).
+- Automatic closing of HMI server instances during installation.
+- TwinCAT Hmi server registered as a service. It doesn't need to be  started manually anymore.
+- Added NuGet package manager.
+
 ## Version 1.10.1336.203
 
 ### Bug fix

--- a/hmi_changelog.md
+++ b/hmi_changelog.md
@@ -1,5 +1,8 @@
 # TE2000: TwinCAT 3 HMI 
 
+## Known bugs
+- PLC properties can only be used explicitly in the HMI by linking the property individually to a control attribute. If the entire function block is linked to a control attribute, the property is not called. This is the case when a function block is used as the source data of the DataGrid or as a user control parameter. 
+
 ## Version 1.12.752.0
 - New EtherCAT Diagnostics 
 


### PR DESCRIPTION
Source InfoSys.

I tested the blacklisting, references resolving and properties calls in 1.12.752.0.
Properties have worked before 1.12 in a similar way, not sure why infosys only stated that its only supported from 1.12. There is still a known issue where properties can only be used if bind directly to a control. I got a reply from Beckhoff support (dating 21/08/2020) that it is a know issue and will be fixed in the next official release (which doesn't seems to be the case yet.).

References and blacklisting seems to work, but doesn't appear always intuitive on the engineering side. Ex. hidden variable inside fb are still inside the datatype, but can't be used, resulting in a warning about schema difference. 

I  was able to run the following setup to map a usercontrol to a fb without all the extra overhead of internal variables:
- Create an abstract fb with variables I want to share inside the HMI.
- Create an extended fb of this abstract with functionality and extra internal variables.
- Create an reference to the abstract fb.
- Import the reference inside the hmi.
- Create a usercontrol with the abstract fb datatype as parameter.
- Bind the reference to an instance of the usercontrol.
This way it's not needed to use pragmas to hide internal variables inside the fb, and all the extra data is not send over ads. (Win=win situation)