### PR TITLE
TF6420 v3.3.34.5 license loading

### DIFF
--- a/docs/functions/TF6420_tc3_database_server.md
+++ b/docs/functions/TF6420_tc3_database_server.md
@@ -1,5 +1,9 @@
 # TF6420 | TwinCAT 3 database server
 
+## Version 3.3.34.5
+
+- Fixes failure to load TF6420 license with auto boot enabled on system startup. A Start/Restart was required to reload the license. Issue seemed to be for newer TF6420 versions running with TwinCAT v3.1.4022 or older.
+
 ## Version 3.3.34.0
 
 - TwinCAT/BSD support added


### PR DESCRIPTION
I reported the issue to USA Support with TF6420 v3.3.34.3 on TC4022. It was confirmed to be a known issue. Support confirmed a fix had been released with v3.3.34.5.