### PR TITLE
Fixed header 'Features' showing up in menu

### DIFF
--- a/docs/tc3.md
+++ b/docs/tc3.md
@@ -120,7 +120,7 @@
 
 ## Version 3.1.4024.29
 
-## Features
+### Features
 
 -   Added: [`Tc2_Utilities.E_HashMode`](https://infosys.beckhoff.com/../content/1033/tcplclib_tc2_utilities/12674322571.html?id=1394075611762795497)
 -   Added: [`Tc2_Utilities.F_GetClassIdVersioned`](https://infosys.beckhoff.com/../content/1033/tcplclib_tc2_utilities/12674393611.html?id=2848447897774806889)


### PR DESCRIPTION
The header 'Features' was accidentally showing up in the menu. Adding 1 '#' fixes this.